### PR TITLE
Fix support for [*][/*] DSL tag

### DIFF
--- a/src/main/java/io/github/eb4j/dsl/DslParser.jj
+++ b/src/main/java/io/github/eb4j/dsl/DslParser.jj
@@ -102,7 +102,7 @@ PARSER_END(DslParser)
 
 <LexStartTag> TOKEN: {
    <TAG_NAME: (<MEAN> | "b" | "br" | "c" | "com" | "ex" | "i" | "lang" | "p" | "preview" | "ref"
-               | "s" | "sub" | "sup" | "t" | "trn" | "trn1" | "trs" | "!trs" | "u" | "video" | "'" ) > : LexInTag
+               | "s" | "sub" | "sup" | "t" | "trn" | "trn1" | "trs" | "!trs" | "u" | "video" | "'" | "*" ) > : LexInTag
   | <LST_ERROR: ~[]> : DEFAULT
 }
 

--- a/src/main/java/io/github/eb4j/dsl/visitor/HtmlDslVisitor.java
+++ b/src/main/java/io/github/eb4j/dsl/visitor/HtmlDslVisitor.java
@@ -92,7 +92,7 @@ public class HtmlDslVisitor extends DslVisitor<String> {
             return;
         }
         // Handle URL and media tags
-        if (tag.isTagName("url") || tag.isTagName("s") || tag.isTagName("video")) {
+        if (tag.isTagName("url") || tag.isTagName("s") || tag.isTagName("video") || tag.isTagName("*")) {
             specialTag = true;
             return;
         }
@@ -156,6 +156,8 @@ public class HtmlDslVisitor extends DslVisitor<String> {
             } else if (endTag.isTagName("s")) {
                 // img tag when image file
                 sb.append("<img src=\"").append(getMediaUrl()).append("\" />");
+            } else if (endTag.isTagName("*")) {
+                sb.append("<!-- <details>").append(current).append("</details> -->");
             }
             specialTag = false;
             current = null;
@@ -238,7 +240,5 @@ public class HtmlDslVisitor extends DslVisitor<String> {
         TAGMAP.put("m9", "<p style=\"text-indent: 90px\">");
         ENDTAGMAP.put("m", "</p>");
         ENDTAGMAP.put("lang", "</span>");
-        TAGMAP.put("*", "<details>");
-        ENDTAGMAP.put("*", "</details>");
     }
 }

--- a/src/main/java/io/github/eb4j/dsl/visitor/HtmlDslVisitor.java
+++ b/src/main/java/io/github/eb4j/dsl/visitor/HtmlDslVisitor.java
@@ -238,5 +238,7 @@ public class HtmlDslVisitor extends DslVisitor<String> {
         TAGMAP.put("m9", "<p style=\"text-indent: 90px\">");
         ENDTAGMAP.put("m", "</p>");
         ENDTAGMAP.put("lang", "</span>");
+        TAGMAP.put("*", "<details>");
+        ENDTAGMAP.put("*", "</details>");
     }
 }

--- a/src/test/java/io/github/eb4j/dsl/DslParserTest.java
+++ b/src/test/java/io/github/eb4j/dsl/DslParserTest.java
@@ -156,4 +156,13 @@ public class DslParserTest {
         assertEquals("<span class=\"lang_en\">abc</span>", visitor.getObject());
     }
 
+    @Test
+    void asteriskHtml() throws ParseException {
+        DslParser parser = DslParser.createParser("[*]abc[/*]");
+        DslArticle article = parser.DslArticle();
+        HtmlDslVisitor visitor = new HtmlDslVisitor();
+        article.accept(visitor);
+        assertEquals("<details>abc</details>", visitor.getObject());
+    }
+
 }

--- a/src/test/java/io/github/eb4j/dsl/DslParserTest.java
+++ b/src/test/java/io/github/eb4j/dsl/DslParserTest.java
@@ -162,7 +162,7 @@ public class DslParserTest {
         DslArticle article = parser.DslArticle();
         HtmlDslVisitor visitor = new HtmlDslVisitor();
         article.accept(visitor);
-        assertEquals("<details>abc</details>", visitor.getObject());
+        assertEquals("<!-- <details>abc</details> -->", visitor.getObject());
     }
 
 }


### PR DESCRIPTION
- Add missing definition for `[*][/*]` tag
- Convert `[*]...[/*]` as `<details>` html tag inside html comment.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>