### PR TITLE
Introduce LFStreamSearcher

### DIFF
--- a/src/main/java/io/github/eb4j/dsl/DslDictionaryLoader.java
+++ b/src/main/java/io/github/eb4j/dsl/DslDictionaryLoader.java
@@ -115,7 +115,7 @@ final class DslDictionaryLoader {
         // prepare creation of index
         byte[] delimiter = Arrays.copyOf(eol, eol.length * 2);
         System.arraycopy(eol, 0, delimiter, eol.length, eol.length);
-        IStreamSearcher eolSearcher = new StreamSearcher(eol);
+        IStreamSearcher eolSearcher = new LFStreamSearcher(charset.equals(StandardCharsets.UTF_16LE));
         IStreamSearcher cardEndSearcher = new StreamSearcher(delimiter);
         List<DslIndex.Entry> entries = new ArrayList<>();
         // build dictionary index

--- a/src/main/java/io/github/eb4j/dsl/DslDictionaryLoader.java
+++ b/src/main/java/io/github/eb4j/dsl/DslDictionaryLoader.java
@@ -115,8 +115,8 @@ final class DslDictionaryLoader {
         // prepare creation of index
         byte[] delimiter = Arrays.copyOf(eol, eol.length * 2);
         System.arraycopy(eol, 0, delimiter, eol.length, eol.length);
-        StreamSearcher eolSearcher = new StreamSearcher(eol);
-        StreamSearcher cardEndSearcher = new StreamSearcher(delimiter);
+        IStreamSearcher eolSearcher = new StreamSearcher(eol);
+        IStreamSearcher cardEndSearcher = new StreamSearcher(delimiter);
         List<DslIndex.Entry> entries = new ArrayList<>();
         // build dictionary index
         try (InputStream is = isDictzip ? new DictZipInputStream(

--- a/src/main/java/io/github/eb4j/dsl/IStreamSearcher.java
+++ b/src/main/java/io/github/eb4j/dsl/IStreamSearcher.java
@@ -1,0 +1,8 @@
+package io.github.eb4j.dsl;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface IStreamSearcher {
+    long search(InputStream stream) throws IOException;
+}

--- a/src/main/java/io/github/eb4j/dsl/LFStreamSearcher.java
+++ b/src/main/java/io/github/eb4j/dsl/LFStreamSearcher.java
@@ -1,0 +1,40 @@
+package io.github.eb4j.dsl;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A lazy line end searcher for Little endian UTF-16, UTF-8, and ANSI.
+ * Just search LF(0x0a) and check UTF-16LE LF (0x0a 0x00).
+ */
+public class LFStreamSearcher implements IStreamSearcher {
+    private static final byte lf = 0x0a;
+    private final boolean isUTF16;
+
+    public LFStreamSearcher(final boolean isUTF16) {
+        this.isUTF16 = isUTF16;
+    }
+
+    public long search(InputStream stream) throws IOException {
+        long bytesRead = 0;
+        int b;
+        while ((b = stream.read()) != -1) {
+            bytesRead++;
+            if ((byte) b == lf) {
+                if (!isUTF16) {
+                    return bytesRead;
+                }
+                bytesRead++;
+                if ((b = stream.read()) == -1) {
+                    // eof
+                    return -1;
+                }
+                if (b == 0x00) {
+                    return bytesRead;
+                }
+            }
+        }
+        // no dice
+        return -1;
+    }
+}

--- a/src/main/java/io/github/eb4j/dsl/StreamSearcher.java
+++ b/src/main/java/io/github/eb4j/dsl/StreamSearcher.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
  * For more on the algorithm works see: https://www.inf.fh-flensburg.de/lang/algorithmen/pattern/kmpen.htm.
  * borrowed from twitter/elephant-bird (apache-2.0)
  */
-public class StreamSearcher {
+public class StreamSearcher implements IStreamSearcher {
 
   protected byte[] pattern;
   protected int[] borders;


### PR DESCRIPTION
Searching EoL (CRLF or LF) can be  just a LF byte searcher when assuming UTF-8, ANSI and UTF-16LE.
When UTF-16LE, check existence of null byte after LF byte.
